### PR TITLE
Fix: replace derive function from derive to deriveChild

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,13 +44,13 @@ export default class EthereumBIP44 {
     }
 
     derive(path) {
-        return this.key.derive(path);
+        return this.key.deriveChild(path);
     }
 
     getAddress(index) {
 
         let path = this.parts.slice(this.key.depth);
-        let derived = this.key.derive('m/' + (path.length > 0 ? path.join('/') + '/' : "") + index);
+        let derived = this.key.deriveChild('m/' + (path.length > 0 ? path.join('/') + '/' : "") + index);
         let address = pubToAddress(
             EthereumBIP44.bip32PublicToEthereumPublic(
                 derived.publicKey.toBuffer()
@@ -61,7 +61,7 @@ export default class EthereumBIP44 {
 
     getPrivateKey(index) {
       let path = this.parts.slice(this.key.depth);
-      let derived = this.key.derive('m/' + (path.length > 0 ? path.join('/') + '/' : "") + index);
+      let derived = this.key.deriveChild('m/' + (path.length > 0 ? path.join('/') + '/' : "") + index);
       return padTo32(derived.privateKey.toBuffer());
     }
 }


### PR DESCRIPTION
[bitcore-lib](https://github.com/bitpay/bitcore/tree/v8.0.0/packages/bitcore-lib) is [deprecated](https://github.com/bitpay/bitcore-lib/blob/master/docs/hierarchical.md) `derive` function.
there is some problem with derive like that private key's bytes will less than 32 bytes while it is converting to bit number and has left padding zero in there.
in the old function - `derive` will take `nonCompliant` for non-BIP32 derivation, but there should be BIP32 derivation, so we should change to `derivedChild`.

